### PR TITLE
Fixed quicktime handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,6 @@
     },
     "autoload": {
         "psr-0": { "GetId3": "" }
-    }
+    },
+    "target-dir": "GetId3"
 }


### PR DESCRIPTION
The Quicktime handler was previously resulting in a Fatal error because the Mp3 handler wasn't referenced properly
