### PR TITLE
Fix fatal private method error

### DIFF
--- a/GetId3Core.php
+++ b/GetId3Core.php
@@ -693,7 +693,7 @@ class GetId3Core
      * @param  string  $message
      * @return boolean
      */
-    private function warning($message)
+    public function warning($message)
     {
         $this->info['warning'][] = $message;
 


### PR DESCRIPTION
When trying to read data from a FLAC file, I'm receiving the following error message:

```
Fatal error:  Call to private method GetId3\GetId3Core::warning() from context 'GetId3\Handler\BaseHandler' in /vagrant/vendor/phansys/getid3/GetId3/Handler/BaseHandler.php on line 215
```

Obviously, making it public fixes the error. Unsure as to whether or not that is the best solution tho.
