### PR TITLE
create_function is deprecated as of PHP7.2

### DIFF
--- a/Lib/Helper.php
+++ b/Lib/Helper.php
@@ -1845,8 +1845,9 @@ class Helper
         if ($capitaliseFirstChar) {
             $origin = ucfirst($origin);
         }
-        $func = create_function('$c', 'return strtoupper($c[1]);');
 
-        return preg_replace_callback('/'.$cahrToReplace.'([a-z])/', $func, $origin);
+        return preg_replace_callback('/' . $cahrToReplace . '([a-z])/', function($c){
+            return strtoupper($c[1]);
+        }, $origin);
     }
 }


### PR DESCRIPTION
So we should use it anymore, since it breaks the library (or at least, some info is missing in the output and it contains an error instead)